### PR TITLE
Configure open-pull-requests-limit for dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,16 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
+# .github/dependabot.yml
 version: 2
 updates:
-  - package-ecosystem: "cargo" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  # Rust Cargo at root
+  - package-ecosystem: "cargo"
+    directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "pnpm" # See documentation for possible values
-    directory: "/src-ui/" # Location of package manifests
+    open-pull-requests-limit: 10
+
+  # pnpm/npm for React in src-ui
+  - package-ecosystem: "npm"
+    directory: "/src-ui"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Added open-pull-requests-limit for pnpm and npm updates.